### PR TITLE
add channel to known_components

### DIFF
--- a/kodexa/platform/client.py
+++ b/kodexa/platform/client.py
@@ -6609,6 +6609,7 @@ class KodexaClient:
                 "message": MessageEndpoint,
                 "prompt": PromptEndpoint,
                 "guidance": GuidanceSetEndpoint,
+                "channel": ChannelEndpoint,
             }
 
             if component_type in known_components:


### PR DESCRIPTION
Anything else needed to allow the following code?

If we plan to name GPT Chats as ("Suggest Taxonomy 1", "Suggest Taxonomy 2", "Column Shift 1", etc...)
May want to check the list of current channels associated with the workspace: 

chat_list = client.channels.list(filters=["workspace.id: 'fc82b60f-67b1-4df8-a5a0-1d1fb633ddb5'"])