### PR TITLE
Adding the endpoints for external data (ENGG-2863)

### DIFF
--- a/kodexa/model/objects.py
+++ b/kodexa/model/objects.py
@@ -3851,6 +3851,18 @@ class DocumentEmbedding(BaseModel):
     node_uuid: Optional[str] = Field(None, alias="nodeUuid")
 
 
+class DocumentExternalData(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+        use_enum_values=True,
+        arbitrary_types_allowed=True,
+        protected_namespaces=("model_config",),
+    )
+
+    external_data: Optional[Dict[str, Any]] = Field(None, alias="externalData")
+    document_family: Optional[DocumentFamily] = Field(None, alias="documentFamily")
+
+
 class DocumentFamily(BaseModel):
     """
 

--- a/kodexa/platform/client.py
+++ b/kodexa/platform/client.py
@@ -86,6 +86,7 @@ from kodexa.model.objects import (
     PageExtensionPack,
     PageOrganization,
     DocumentFamilyStatistics, MessageContext, PagePrompt, Prompt, GuidanceSet, PageGuidanceSet, DocumentEmbedding,
+    DocumentExternalData,
 )
 
 logger = logging.getLogger()
@@ -4454,6 +4455,28 @@ class DocumentFamilyEndpoint(DocumentFamily, ClientEndpoint):
         """
         url = f"/api/documentFamilies/{self.id}/touch"
         response = self.client.get(url)
+        process_response(response)
+
+    def get_external_data(self) -> DocumentExternalData:
+        """
+        Get the external data of the document family.
+
+        Returns:
+            DocumentExternalData: The external data of the document family.
+        """
+        url = f"/api/documentFamilies/{self.id}/externalData"
+        response = self.client.get(url)
+        return DocumentExternalData.model_validate(response.json())
+
+    def update_external_data(self, external_data: DocumentExternalData):
+        """
+        Update the external data of the document family.
+
+        Args:
+            external_data (DocumentExternalData): The external data to update.
+        """
+        url = f"/api/documentFamilies/{self.id}/externalData"
+        response = self.client.put(url, body=external_data.model_dump(mode="json", by_alias=True))
         process_response(response)
 
     def export(self) -> bytes:


### PR DESCRIPTION
This pull request introduces changes to the `kodexa/model/objects.py` and `kodexa/platform/client.py` files. The changes are primarily focused on the addition of `DocumentExternalData` class and its methods for managing external data of the document family. 

New class and methods:

* [`kodexa/model/objects.py`](diffhunk://#diff-100575ad7799ddb035e347e771298cbe6110e33c632c933aa69f14fdb2c8a178R3854-R3865): Added a new class `DocumentExternalData` that includes a model configuration and two optional fields: `external_data` and `document_family`. This class is used to manage the external data of a document family.

* [`kodexa/platform/client.py`](diffhunk://#diff-6683e081d419f50ec04ba7727d97361c0169cbe7d4255d05a0c403a5e4b9bed3R89): Imported the `DocumentExternalData` class to the file.

* [`kodexa/platform/client.py`](diffhunk://#diff-6683e081d419f50ec04ba7727d97361c0169cbe7d4255d05a0c403a5e4b9bed3R4460-R4481): Added two new methods `get_external_data` and `update_external_data` in the `touch` method. The `get_external_data` method fetches the external data of the document family, and the `update_external_data` method updates the external data of the document family.