### PR TITLE
ENGG-2855: Checklist

### DIFF
--- a/kodexa/model/entities/check_response.py
+++ b/kodexa/model/entities/check_response.py
@@ -36,7 +36,6 @@ class CheckResponse(BaseModel):
     status: Optional[CheckStatus] = None
     confidence: Optional[float] = None
     approver: Optional[User] = None
-    data_object_id: Optional[str] = Field(None, alias="dataObjectId")
 
 
 class PageCheckResponse(BaseModel):

--- a/kodexa/model/entities/check_response.py
+++ b/kodexa/model/entities/check_response.py
@@ -1,0 +1,133 @@
+from typing import Optional, List
+
+from pydantic import BaseModel, ConfigDict, Field
+from kodexa.model.base import StandardDateTime
+from kodexa.model.objects import User
+from kodexa.platform.client import EntityEndpoint, PageEndpoint, EntitiesEndpoint
+
+from enum import Enum
+
+
+class CheckStatus(Enum):
+    """ Check Status ENUM: OPEN, CLOSED, IN_PROGRESS """
+    open = "OPEN"
+    closed = "CLOSED"
+    in_progress = "IN_PROGRESS"
+
+
+class CheckResponse(BaseModel):
+    """
+    Entity of check response
+    """
+    model_config = ConfigDict(
+        populate_by_name=True,
+        use_enum_values=True,
+        arbitrary_types_allowed=True,
+        protected_namespaces=("model_config",),
+    )
+
+    id: Optional[str] = Field(None)
+    uuid: Optional[str] = None
+    change_sequence: Optional[int] = Field(None, alias="changeSequence")
+    created_on: Optional[StandardDateTime] = Field(None, alias="createdOn")
+    updated_on: Optional[StandardDateTime] = Field(None, alias="updatedOn")
+    title: Optional[str] = None
+    description: Optional[str] = None
+    status: Optional[CheckStatus] = None
+    confidence: Optional[float] = None
+    approver: Optional[User] = None
+    data_object_id: Optional[str] = Field(None, alias="dataObjectId")
+
+
+class PageCheckResponse(BaseModel):
+    """
+        A page pydantic for check response
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        use_enum_values=True,
+        arbitrary_types_allowed=True,
+        protected_namespaces=("model_config",),
+    )
+    total_pages: Optional[int] = Field(None, alias="totalPages")
+    total_elements: Optional[int] = Field(None, alias="totalElements")
+    size: Optional[int] = None
+    content: Optional[List[CheckResponse]] = None
+    number: Optional[int] = None
+    number_of_elements: Optional[int] = Field(None, alias="numberOfElements")
+    first: Optional[bool] = None
+    last: Optional[bool] = None
+    empty: Optional[bool] = None
+
+
+class PageCheckResponseEndpoint(PageCheckResponse, PageEndpoint):
+    """
+        Represents a page check response endpoint
+
+        This class is used to represent the endpoints of a page check response. It inherits from
+        the PageCheckResponse and PageEndpoint classes.
+
+        Methods:
+            get_type: Returns the type of the endpoint.
+    """
+
+    def get_type(self) -> str:
+        """Get the type of the endpoint
+
+        This method is used to get the type of the endpoint. In this case, it will always
+        return "workspace".
+
+        Returns:
+            str: The type of the endpoint, "workspace".
+        """
+        return "checkResponse"
+
+
+class CheckResponseEndpoint(CheckResponse, EntityEndpoint):
+    """Represents a Check Response endpoint"""
+
+    def get_type(self) -> str:
+        """
+        Get the type of endpoint
+
+        :return: The type of endpoint
+        """
+        return "checkResponses"
+
+
+class CheckResponsesEndpoint(EntitiesEndpoint):
+    """ Represents check responses endpoint """
+
+    def get_type(self) -> str:
+        """
+            Get the type of endpoint
+        :return: The type of endpoint
+        """
+        return "checkResponses"
+
+    def get_instance_class(self, object_dict=None) -> CheckResponseEndpoint:
+        """Get the instance class of the endpoint
+
+        This method is used to get the instance class of the endpoint.
+
+        Args:
+            object_dict (dict, optional): A dictionary containing the object data.
+
+        Returns:
+            CheckResponseEndpoint: The instance class of the endpoint.
+        """
+        return CheckResponseEndpoint
+
+    def get_page_class(self, object_dict=None) -> PageCheckResponseEndpoint:
+        """Get the page class of the endpoint
+
+        This method is used to get the page class of the endpoint.
+
+        Args:
+            object_dict (dict, optional): A dictionary containing the object data.
+
+        Returns:
+            PageCheckResponseEndpoint: The page class of the endpoint.
+        """
+        return PageCheckResponseEndpoint

--- a/kodexa/model/objects.py
+++ b/kodexa/model/objects.py
@@ -779,6 +779,8 @@ class ChecklistDefinition(BaseModel):
 
     title: Optional[str] = None
     description: Optional[str] = None
+    definition: Optional[str] = None
+    type: Optional[str] = None
 
 
 class ScheduleDefinition(BaseModel):

--- a/kodexa/model/objects.py
+++ b/kodexa/model/objects.py
@@ -766,6 +766,21 @@ class RelatedTaxon(BaseModel):
     priority: Optional[int] = None
 
 
+class ChecklistDefinition(BaseModel):
+    """
+        Checklist Definiton
+    """
+    model_config = ConfigDict(
+        populate_by_name=True,
+        use_enum_values=True,
+        arbitrary_types_allowed=True,
+        protected_namespaces=("model_config",),
+    )
+
+    title: Optional[str] = None
+    description: Optional[str] = None
+
+
 class ScheduleDefinition(BaseModel):
     """
 
@@ -2665,6 +2680,8 @@ class Taxon(BaseModel):
     cardinality: Optional[TaxonCardinality] = None
 
     conditional_formats: Optional[List[TaxonConditionalFormat]] = Field(None, alias="conditionalFormats")
+
+    checklist_definitions: Optional[List[ChecklistDefinition]] = Field(None, alias="checklistDefinitions")
 
     def update_path(self, parent_path=None):
         if parent_path is None:

--- a/kodexa/platform/client.py
+++ b/kodexa/platform/client.py
@@ -6924,6 +6924,7 @@ class KodexaClient:
 
             from kodexa.model.entities.product import ProductEndpoint
             from kodexa.model.entities.product_subscription import ProductSubscriptionEndpoint
+            from kodexa.model.entities.check_response import CheckResponseEndpoint
             known_components = {
                 "taxonomy": TaxonomyEndpoint,
                 "pipeline": PipelineEndpoint,
@@ -6949,6 +6950,7 @@ class KodexaClient:
                 "channel": ChannelEndpoint,
                 "product": ProductEndpoint,
                 "productSubscription": ProductSubscriptionEndpoint,
+                "checkResponse": CheckResponseEndpoint
             }
 
             if component_type in known_components:


### PR DESCRIPTION
This pull request primarily focuses on the addition of a new feature related to check responses in the `kodexa` package. The changes introduce new classes to handle check responses and their corresponding endpoints. The deserialization method in `kodexa/platform/client.py` has also been updated to recognize these new classes.

Key Changes:

* [`kodexa/model/entities/check_response.py`](diffhunk://#diff-57c770b08931ab75ba6ad5662a8a623f0fbf269219f17f11b61650bfc65522abR1-R133): Introduced new classes `CheckStatus`, `CheckResponse`, `PageCheckResponse`, `PageCheckResponseEndpoint`, `CheckResponseEndpoint`, and `CheckResponsesEndpoint`. These classes are designed to handle check responses and their respective endpoints. `CheckStatus` is an enumeration representing the status of a check. `CheckResponse` and `PageCheckResponse` are models for the check response entity and its paginated version, respectively. `CheckResponseEndpoint`, `PageCheckResponseEndpoint`, and `CheckResponsesEndpoint` are classes representing the corresponding endpoints for these entities. Each endpoint class includes methods to get the type of the endpoint and, for `CheckResponsesEndpoint`, to get the instance and page classes of the endpoint.

* [`kodexa/platform/client.py`](diffhunk://#diff-6683e081d419f50ec04ba7727d97361c0169cbe7d4255d05a0c403a5e4b9bed3R6927): Updated the `deserialize` method to recognize the new `CheckResponseEndpoint`. This allows the client to correctly deserialize check responses received from the server. [[1]](diffhunk://#diff-6683e081d419f50ec04ba7727d97361c0169cbe7d4255d05a0c403a5e4b9bed3R6927) [[2]](diffhunk://#diff-6683e081d419f50ec04ba7727d97361c0169cbe7d4255d05a0c403a5e4b9bed3R6953)