### PR TITLE
Add priority field to Task model

### DIFF
--- a/kodexa/model/objects.py
+++ b/kodexa/model/objects.py
@@ -3388,6 +3388,7 @@ class Task(BaseModel):
     task_document_families: List[TaskDocumentFamily] = Field(default_factory=list, alias="taskDocumentFamilies")
     search_text: Optional[str] = Field(None, alias="searchText")
     tags: List[TaskTag] = Field(default_factory=list)
+    priority: Optional[int] = Field(None, ge=1, le=5, description="Task priority from 1 (lowest) to 5 (highest)")
 
 
 class FeatureSet(BaseModel):


### PR DESCRIPTION
Introduces an optional 'priority' field to the Task model, allowing tasks to be assigned a priority level from 1 (lowest) to 5 (highest).