### PR TITLE
fix: bump urllib3 to 2.6.0 for CVE-2025-66418 and CVE-2025-66471

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 python = ">=3.11, <3.14"
 requests = "^2.28.1"
 msgpack = "^1.0.6"
-urllib3 = "^2.0.0"
+urllib3 = "^2.6.0"
 ply = ">=3.11,<4.0"
 pyyaml = "^6.0"
 deepdiff = ">=8.6.1"


### PR DESCRIPTION
## Summary

- Bumps minimum urllib3 version from `^2.0.0` to `^2.6.0` to address two high severity CVEs

## Vulnerabilities Addressed

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2025-66418 | High (8.9) | Unbounded decompression chain allowing DoS via CPU/memory exhaustion |
| CVE-2025-66471 | High (8.9) | Improper handling of highly compressed data in Streaming API |

## Impact

This fix will cascade to all downstream repositories that depend on `kodexa`:
- server
- kodexa-cli
- kodexa-platform
- kodexa-document
- extension-core
- extension-model-runtime
- cass-analysis
- smbc-analysis
- cass-telecom
- kodexa-data-operations

Once this PR is merged and a new version of `kodexa` is published, downstream repos need to update their lockfiles to pick up the fix.

## Test plan

- [ ] Verify urllib3 2.6.0+ is compatible with existing functionality
- [ ] Run existing test suite

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency constraint to remediate security issues.
> 
> - In `pyproject.toml`, bump `urllib3` from `^2.0.0` to `^2.6.0`
> - Security: addresses CVE-2025-66418 and CVE-2025-66471
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e322f122dbab390636c0238ccc34862b1a013dfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->